### PR TITLE
Add Joke Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -1,8 +1,6 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.ucsb.cs156.spring.backenddemo.services.CollegeSubredditQueryService;
 import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,16 +11,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name="College Subreddits from https://github.com/karlding/college-subreddits/")
+@Tag(name="Jokes from https://v2.jokeapi.dev/joke/")
 @RestController
 @RequestMapping("/api/jokes")
 public class JokeController {
-    ObjectMapper mapper = new ObjectMapper();
 
     @Autowired
     JokeQueryService jokeQueryService;
 
-    @Operation(summary = "Get a list of college subreddits")
+    @Operation(summary = "Get a list of jokes")
     @GetMapping("/get")
     public ResponseEntity<String> get(
             @RequestParam String category,

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -1,8 +1,34 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.CollegeSubredditQueryService;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name="College Subreddits from https://github.com/karlding/college-subreddits/")
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Get a list of college subreddits")
+    @GetMapping("/get")
+    public ResponseEntity<String> get(
+            @RequestParam String category,
+            @RequestParam int numJokes
+    ) throws JsonProcessingException {
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,85 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    JokeQueryService mockJokeQueryService;
+
+
+    @Test
+    public void test_getJokes() throws Exception {
+        String fakeJsonResult="""
+                {
+                    "error": false,
+                    "amount": 2,
+                    "jokes": [
+                        {
+                            "category": "Programming",
+                            "type": "single",
+                            "joke": "A SQL statement walks into a bar and sees two tables.\\nIt approaches, and asks \\"may I join you?\\"",
+                            "flags": {
+                                "nsfw": false,
+                                "religious": false,
+                                "political": false,
+                                "racist": false,
+                                "sexist": false,
+                                "explicit": false
+                            },
+                            "id": 5,
+                            "safe": true,
+                            "lang": "en"
+                        },
+                        {
+                            "category": "Programming",
+                            "type": "twopart",
+                            "setup": "How do you know God is a shitty programmer?",
+                            "delivery": "He wrote the OS for an entire universe, but didn't leave a single useful comment.",
+                            "flags": {
+                                "nsfw": false,
+                                "religious": true,
+                                "political": false,
+                                "racist": false,
+                                "sexist": false,
+                                "explicit": true
+                            },
+                            "id": 19,
+                            "safe": false,
+                            "lang": "en"
+                        }
+                    ]
+                }""";
+        String category = "Programming";
+        int numJokes = 2;
+        when(mockJokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?category=%s&numJokes=%s", category, numJokes);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(value = JokeController.class)
 public class JokeControllerTests {
-    private ObjectMapper mapper = new ObjectMapper();
     @Autowired
     private MockMvc mockMvc;
     @MockBean
@@ -27,46 +25,7 @@ public class JokeControllerTests {
 
     @Test
     public void test_getJokes() throws Exception {
-        String fakeJsonResult="""
-                {
-                    "error": false,
-                    "amount": 2,
-                    "jokes": [
-                        {
-                            "category": "Programming",
-                            "type": "single",
-                            "joke": "A SQL statement walks into a bar and sees two tables.\\nIt approaches, and asks \\"may I join you?\\"",
-                            "flags": {
-                                "nsfw": false,
-                                "religious": false,
-                                "political": false,
-                                "racist": false,
-                                "sexist": false,
-                                "explicit": false
-                            },
-                            "id": 5,
-                            "safe": true,
-                            "lang": "en"
-                        },
-                        {
-                            "category": "Programming",
-                            "type": "twopart",
-                            "setup": "How do you know God is a shitty programmer?",
-                            "delivery": "He wrote the OS for an entire universe, but didn't leave a single useful comment.",
-                            "flags": {
-                                "nsfw": false,
-                                "religious": true,
-                                "political": false,
-                                "racist": false,
-                                "sexist": false,
-                                "explicit": true
-                            },
-                            "id": 19,
-                            "safe": false,
-                            "lang": "en"
-                        }
-                    ]
-                }""";
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
         String category = "Programming";
         int numJokes = 2;
         when(mockJokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);


### PR DESCRIPTION
In this PR, we add an endpoint `/api/jokes/get` that can be used to get a certain amount of jokes of a particular category.

Closes #7