### PR TITLE
pc - update workflow 04 per Dagin to fix errors

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1-backend.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1-backend.yml
@@ -250,7 +250,7 @@ jobs:
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         branch: ${{ env.branch_name }}
         name: pitest-${{ matrix.value.number }}-history.bin

--- a/.github/workflows/04-gh-pages-redeploy-part-2-backend.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2-backend.yml
@@ -128,7 +128,7 @@ jobs:
     - name: c-jacoco Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{ github.token }}
         name: jacoco
         path: ${{ env.jacoco_dest }}
@@ -149,7 +149,7 @@ jobs:
     - name:  d-pitest Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{ github.token }}
         name: pitest
         path: ${{ env.pitest_dest }}
@@ -187,7 +187,7 @@ jobs:
     - name: a-javadoc Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{ github.token }}
         name: prs-${{ matrix.value.number }}-javadoc
         path: ${{ env.javadoc_dest }}
@@ -209,7 +209,7 @@ jobs:
     - name:  c-jacoco Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{ github.token }}
         name: prs-${{ matrix.value.number }}-jacoco
         path: ${{ env.jacoco_dest }}
@@ -230,7 +230,7 @@ jobs:
     - name: d-pitest Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
+        workflow: 02-gh-pages-rebuild-part-1-backend.yml
         github_token: ${{ github.token }}
         name: prs-${{ matrix.value.number }}-pitest
         path: ${{ env.pitest_dest }}


### PR DESCRIPTION
In this PR, we apply changes from Dagin on team f23-6pm-1 to workflow 04 to fix errors in the artifact downloads generated by workflow 02.